### PR TITLE
Add top and bottom rule default params. Remove non-working multiindex code

### DIFF
--- a/statstables/__init__.py
+++ b/statstables/__init__.py
@@ -21,3 +21,5 @@ STParams["ascii_footer_char"] = "="
 STParams["ascii_border_char"] = ""
 STParams["ascii_mid_rule_char"] = "-"
 STParams["underline_multicolumn"] = False
+STParams["double_top_rule"] = True
+STParams["double_bottom_rule"] = False

--- a/statstables/renderers.py
+++ b/statstables/renderers.py
@@ -69,6 +69,8 @@ class LatexRenderer(Renderer):
             content_columns = "l" + content_columns
         header += "\\begin{tabular}{" + content_columns + "}\n"
         header += "  \\toprule\n"
+        if st.STParams["double_top_rule"]:
+            header += "  \\toprule\n"
         for col, spans in self.table._multicolumns:
             header += ("  " + self.table.index_name + " & ") * self.table.include_index
             header += " & ".join(
@@ -117,6 +119,8 @@ class LatexRenderer(Renderer):
             for line in self.table.custom_lines["after-footer"]:
                 footer += self._create_line(line)
             footer += "  \\bottomrule\n"
+            if st.STParams["double_bottom_rule"]:
+                footer += "  \\bottomrule\n"
         if self.table.notes:
             for note, alignment, escape in self.table.notes:
                 align_cols = self.table.ncolumns + self.table.include_index
@@ -281,6 +285,11 @@ class ASCIIRenderer(Renderer):
             st.STParams["ascii_header_char"] * (self._len + (2 * self._border_len))
             + "\n"
         )
+        if st.STParams["double_top_rule"]:
+            header = (
+                st.STParams["ascii_header_char"] * (self._len + (2 * self._border_len))
+                + "\n"
+            )
         underlines = st.STParams["ascii_border_char"]
         for col, span in self.table._multicolumns:
             header += st.STParams["ascii_border_char"] + (
@@ -329,6 +338,10 @@ class ASCIIRenderer(Renderer):
 
     def generate_footer(self) -> str:
         footer = st.STParams["ascii_footer_char"] * (self._len + (2 * self._border_len))
+        if st.STParams["double_bottom_rule"]:
+            footer = st.STParams["ascii_footer_char"] * (
+                self._len + (2 * self._border_len)
+            )
         if self.table.notes:
             for note, alignment, _ in self.table.notes:
                 footer += "\n"

--- a/statstables/tables.py
+++ b/statstables/tables.py
@@ -30,7 +30,7 @@ class Table(ABC):
         self._index_labels = dict()
         self._column_labels = dict()
         self._multicolumns = []
-        self._multiindex = {}
+        # self._multiindex = []
         self._formatters = dict()
         self.notes = []
         self.custom_lines = defaultdict(list)
@@ -39,6 +39,14 @@ class Table(ABC):
         self.include_index = False
         self.index_name = ""
         self.show_columns = True
+
+    @property
+    def ncolumns(self) -> int:
+        return self._ncolumns
+
+    @ncolumns.setter
+    def ncolumns(self, ncolumns: int) -> None:
+        self._ncolumns = ncolumns
 
     @property
     def caption_location(self) -> str:
@@ -201,24 +209,24 @@ class Table(ABC):
         ), "The sum of spans must equal the number of columns"
         self._multicolumns.append((columns, spans))
 
-    def add_multiindex(self, index: list[str], spans: list[tuple]) -> None:
-        """
-        Add a multiindex to the table. This will be placed above the index column
-        in the table. The sum of the spans must equal the number of rows in the table.
+    # def add_multiindex(self, index: list[str], spans: list[tuple]) -> None:
+    #     """
+    #     Add a multiindex to the table. This will be placed above the index column
+    #     in the table. The sum of the spans must equal the number of rows in the table.
 
-        Parameters
-        ----------
-        index : list[str]
-            List of labels for the multiindex
-        spans : list[tuple]
-            List of tuples that indicate where the index should start and how many
-            rows it should span. The first element of the tuple should be the row
-            it starts and the second should be the number of rows it spans.
-        """
-        assert len(index) == len(spans), "index and spans must be the same length"
-        self._multiindex.append((index, spans))
-        for i, s in zip(index, spans):
-            self._multiindex[s[0]] = {"index": i, "end": s[1]}
+    #     Parameters
+    #     ----------
+    #     index : list[str]
+    #         List of labels for the multiindex
+    #     spans : list[tuple]
+    #         List of tuples that indicate where the index should start and how many
+    #         rows it should span. The first element of the tuple should be the row
+    #         it starts and the second should be the number of rows it spans.
+    #     """
+    #     assert len(index) == len(spans), "index and spans must be the same length"
+    #     self._multiindex.append((index, spans))
+    #     for i, s in zip(index, spans):
+    #         self._multiindex[s[0]] = {"index": i, "end": s[1]}
 
     def custom_formatters(self, formatters: dict) -> None:
         """
@@ -542,7 +550,7 @@ class GenericTable(Table):
     column/index naming
     """
 
-    def __init__(self, df: pd.DataFrame):
+    def __init__(self, df: pd.DataFrame | pd.Series):
         self.df = df
         self.ncolumns = df.shape[1]
         self.columns = df.columns
@@ -562,8 +570,8 @@ class GenericTable(Table):
                 _row.append(formated_val)
             if not self.include_index:
                 _row.pop(0)
-            if _index in self._multiindex.keys():
-                _row.insert(0, self._multiindex[_index]["index"])
+            # if _index in self._multiindex.keys():
+            #     _row.insert(0, self._multiindex[_index]["index"])
             rows.append(_row)
         return rows
 


### PR DESCRIPTION
New defaults allow user to specify whether they want their tables to have one or two rules on the top and bottom of their tables. Despite the branch name, this actually removes code for creating a multi index because it doesn't work yet.